### PR TITLE
Polish compare numbers notification banners

### DIFF
--- a/src/pages/compare-numbers/CompareNumbersGame.tsx
+++ b/src/pages/compare-numbers/CompareNumbersGame.tsx
@@ -124,7 +124,9 @@ const NOTIFICATION_STYLES: Record<NotificationVariant, string> = {
   muted: "border-muted-foreground/30 bg-muted/50 text-muted-foreground",
 };
 
-interface NotificationBannerProps extends React.ComponentProps<typeof Alert> {
+type AlertProps = React.ComponentProps<typeof Alert>;
+
+interface NotificationBannerProps extends Omit<AlertProps, "variant"> {
   variant?: NotificationVariant;
   children: React.ReactNode;
 }
@@ -441,6 +443,8 @@ export default function CompareNumbersGame() {
     return `${pad(minutes)}:${pad(remaining)}`;
   }, []);
 
+  const sessionEnded = screen === "play" && gameOver;
+
   const feedbackNotification = React.useMemo<NotificationPayload | null>(() => {
     if (!feedback) return null;
     if (feedback.type === "correct") {
@@ -629,8 +633,6 @@ export default function CompareNumbersGame() {
     }
     setTaskId((id) => id + 1);
   }, [screen, startSession, resetTimer]);
-
-  const sessionEnded = screen === "play" && gameOver;
 
   const displaySizeClass = React.useMemo(() => {
     const leftLength = exercise?.left.display.length ?? 0;


### PR DESCRIPTION
## Summary
- add a reusable notification banner wrapper around the shadcn Alert component for the compare numbers game
- extract feedback and session end messages into memoized notification payloads and reuse the banner beneath the stats block
- keep the telemetry notice centered with the shared banner styling and document when it is shown

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb0f124cc8326802045e43a3eab9a)