### PR TITLE
Ensure session notifications override feedback in compare numbers

### DIFF
--- a/src/pages/compare-numbers/CompareNumbersGame.tsx
+++ b/src/pages/compare-numbers/CompareNumbersGame.tsx
@@ -494,10 +494,11 @@ export default function CompareNumbersGame() {
   }, [endReason, maxExercises, sessionEnded, totalExercises, tr]);
 
   const activeNotifications = React.useMemo(() => {
-    return [feedbackNotification, sessionNotification].filter(
-      (notification): notification is NotificationPayload =>
-        notification !== null,
-    );
+    if (sessionNotification) {
+      return [sessionNotification];
+    }
+
+    return feedbackNotification ? [feedbackNotification] : [];
   }, [feedbackNotification, sessionNotification]);
 
   function sanitizeNonNegativeConfig(update: Partial<IntegerState>) {


### PR DESCRIPTION
## Summary
- update notification aggregation so session-ending messages replace prior feedback alerts

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fd028277883268ed8f8d7decfeb47)