### PR TITLE
Ensure rounding game settings open at top

### DIFF
--- a/src/pages/rounding-trainer/RoundingGame.tsx
+++ b/src/pages/rounding-trainer/RoundingGame.tsx
@@ -340,6 +340,13 @@ export default function RoundingGame() {
     const [options, setOptions] = React.useState<number[]>([]);
     const [taskId, setTaskId] = React.useState<number>(0);
 
+    // Ensure the settings screen always starts at the top when opened
+    React.useEffect(() => {
+        if (screen === "setup") {
+            window.scrollTo({top: 0, left: 0, behavior: "auto"});
+        }
+    }, [screen]);
+
     // Input mode state
     const [answer, setAnswer] = React.useState<string>("");
     const inputRef = React.useRef<HTMLInputElement>(null);


### PR DESCRIPTION
## Summary
- scroll the rounding game settings view to the top whenever it opens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924f99441a4832691a366a0ac1ae9cf)