### PR TITLE
Render command menu only when keyboard shortcuts supported

### DIFF
--- a/src/components/menu/AppHeader.tsx
+++ b/src/components/menu/AppHeader.tsx
@@ -12,7 +12,8 @@ function useKeyboardShortcutSupport() {
     React.useEffect(() => {
         const userAgent = navigator.userAgent || "";
         const isMobileAgent = /android|iphone|ipad|ipod|mobile/i.test(userAgent);
-        const isMobileDevice = navigator.userAgentData?.mobile ?? isMobileAgent;
+        const uaData = (navigator as Navigator & {userAgentData?: {mobile?: boolean}}).userAgentData;
+        const isMobileDevice = uaData?.mobile ?? isMobileAgent;
 
         setIsSupported(!isMobileDevice);
     }, []);


### PR DESCRIPTION
## Summary
- add a keyboard shortcut capability check to the app header
- hide the command menu and shortcut trigger on mobile-only devices
- show platform-appropriate shortcut text when supported

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924fd44c334832691cb57b508ddba8b)