### PR TITLE
Set quiz mode as default in trainers

### DIFF
--- a/src/pages/multiplication-trainer/MultiplicationTrainer.tsx
+++ b/src/pages/multiplication-trainer/MultiplicationTrainer.tsx
@@ -140,7 +140,7 @@ export default function MultiplicationTrainer() {
 
   // UI state
   const [screen, setScreen] = React.useState<Screen>("setup");
-  const [mode, setMode] = React.useState<Mode>("input");
+  const [mode, setMode] = React.useState<Mode>("quiz");
 
   // Config
   const [minVal, setMinVal] = React.useState<number>(4);
@@ -476,11 +476,11 @@ export default function MultiplicationTrainer() {
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="input">
-                          {t("multiT.mode.input")}
-                        </SelectItem>
                         <SelectItem value="quiz">
                           {t("multiT.mode.quiz")}
+                        </SelectItem>
+                        <SelectItem value="input">
+                          {t("multiT.mode.input")}
                         </SelectItem>
                       </SelectContent>
                     </Select>

--- a/src/pages/rounding-trainer/RoundingGame.tsx
+++ b/src/pages/rounding-trainer/RoundingGame.tsx
@@ -332,7 +332,7 @@ export default function RoundingGame() {
 
   // UI state
   const [screen, setScreen] = React.useState<Screen>("setup");
-  const [mode, setMode] = React.useState<Mode>("input");
+  const [mode, setMode] = React.useState<Mode>("quiz");
 
   // Config: filters
   const [includeWhole, setIncludeWhole] = React.useState<boolean>(true);
@@ -747,11 +747,11 @@ export default function RoundingGame() {
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="input">
-                          {RT.labels.modeInput}
-                        </SelectItem>
                         <SelectItem value="quiz">
                           {RT.labels.modeQuiz}
+                        </SelectItem>
+                        <SelectItem value="input">
+                          {RT.labels.modeInput}
                         </SelectItem>
                       </SelectContent>
                     </Select>


### PR DESCRIPTION
## Summary
- default both multiplication and rounding trainers to quiz mode
- reorder mode selectors so the quiz option appears first

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927d608437c83268b7099fd8e991877)