### PR TITLE
Improve Jumping Rabbit quiz and effects

### DIFF
--- a/src/pages/jumping-rabbit/JumpingRabbit.tsx
+++ b/src/pages/jumping-rabbit/JumpingRabbit.tsx
@@ -138,9 +138,11 @@ export default function RabbitJumpX9({
       setTimeout(() => playTone(920, 0.16, 0.08, "triangle"), 70);
       setTimeout(() => playTone(1080, 0.18, 0.06, "triangle"), 140);
     } else if (kind === "firework") {
-      playTone(840, 0.14, 0.08, "triangle");
-      setTimeout(() => playTone(720, 0.12, 0.07, "sine"), 60);
-      setTimeout(() => playTone(960, 0.18, 0.06, "triangle"), 120);
+      // Two low booms followed by a bright crackle
+      playTone(220, 0.18, 0.16, "sine");
+      setTimeout(() => playTone(180, 0.2, 0.14, "sine"), 90);
+      setTimeout(() => playTone(840, 0.14, 0.08, "triangle"), 180);
+      setTimeout(() => playTone(960, 0.18, 0.06, "triangle"), 260);
     }
   };
 


### PR DESCRIPTION
## Summary
- add optional sound/vibration feedback and audio priming for the Jumping Rabbit experience
- give the rabbit safe landing space on collisions and let players skip the quiz requirement via a toggle
- replace free-text multiplication answers with four-option quizzes and refreshed hit dialogs

## Testing
- npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694360407684832690ea4aac80ed02d4)