### PR TITLE
Add Telegram-aware header provider, wire into layouts, and add PrivateMenu page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import WebLayout from "./layout/WebLayout.tsx";
 import {Navigate} from "react-router-dom";
 import SettingsPage from "@/pages/SettingsPage.tsx";
 import SubscriptionPage from "@/pages/subscriptions/SubscriptionPage.tsx";
+import PrivateMenuPage from "@/pages/PrivateMenuPage.tsx";
 
 export default function App() {
   return (
@@ -25,7 +26,7 @@ export default function App() {
       <Route path="telegram/login" element={<DefaultLayout><LoginPage/></DefaultLayout>}/>
       <Route element={<PrivateRoute/>}>
           <Route element={<WebLayout><Outlet/></WebLayout>}>
-              <Route path="private-menu" element={<h1 className="text-2xl">Private Menu Page</h1>}/>
+              <Route path="private-menu" element={<PrivateMenuPage/>}/>
               <Route path="settings" element={<SettingsPage/>}/>
               <Route path="subscriptions" element={<SubscriptionPage/>}/>
           </Route>

--- a/src/components/menu/AppHeader.tsx
+++ b/src/components/menu/AppHeader.tsx
@@ -25,10 +25,15 @@ function useKeyboardShortcutSupport() {
   return isSupported;
 }
 
-export default function AppHeader() {
+type AppHeaderProps = {
+  title?: string;
+};
+
+export default function AppHeader({ title }: AppHeaderProps) {
   const { t } = useTranslation();
   const [isMac, setIsMac] = React.useState(false);
   const supportsShortcut = useKeyboardShortcutSupport();
+  const resolvedTitle = title ?? t("menu.title");
 
   React.useEffect(() => {
     const platform = navigator.platform || "";
@@ -42,7 +47,7 @@ export default function AppHeader() {
         <div className="flex items-center gap-2">
           <div className="size-8 rounded bg-primary/10" aria-hidden />
           <span className="text-lg font-semibold leading-none">
-            {t("menu.title")}
+            {resolvedTitle}
           </span>
         </div>
       </div>

--- a/src/layout/CommonLayout.tsx
+++ b/src/layout/CommonLayout.tsx
@@ -1,93 +1,17 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Outlet } from "react-router";
-import WebApp from "@twa-dev/sdk";
-
-type HeaderContextType = {
-  setHeader: (node: React.ReactNode | null) => void;
-  setHeaderVisible: (visible: boolean) => void;
-};
-
-const HeaderContext = React.createContext<HeaderContextType | undefined>(
-  undefined,
-);
-
-/**
- * Hook for child pages to set custom header content and control visibility of the common header.
- *
- * Example usage inside a page component:
- *   useCustomHeader(<MyHeaderContent />, { visible: true });
- */
-export function useCustomHeader(
-  content?: React.ReactNode,
-  options?: { visible?: boolean; deps?: React.DependencyList },
-) {
-  const ctx = React.useContext(HeaderContext);
-  // If used outside of CommonLayout, do nothing to avoid runtime errors
-  if (!ctx) return;
-
-  const { setHeader, setHeaderVisible } = ctx;
-  const visible = options?.visible ?? true;
-  const deps = options?.deps ?? [content, visible];
-
-  React.useEffect(() => {
-    if (visible) {
-      setHeader(content ?? null);
-      setHeaderVisible(true);
-    } else {
-      setHeaderVisible(false);
-    }
-    return () => {
-      // Cleanup on unmount or dependency change
-      setHeader(null);
-      setHeaderVisible(false);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
-}
+import {
+  TelegramHeaderProvider,
+  useCustomHeader,
+} from "@/layout/TelegramHeader";
 
 const CommonLayout: React.FC = () => {
-  const [header, setHeader] = React.useState<React.ReactNode | null>(null);
-  const [renderHeaderBlock, setRenderHeaderBlock] =
-    React.useState<boolean>(false);
-  const [headerVisible, setHeaderVisible] = React.useState<boolean>(false);
-
-  useEffect(() => {
-    if (WebApp) {
-      WebApp.ready();
-      if (
-        WebApp.initDataUnsafe &&
-        Object.keys(WebApp.initDataUnsafe).length > 0
-      ) {
-        setRenderHeaderBlock(WebApp.isFullscreen);
-        console.log("Telegram WebApp is available: ", WebApp);
-        console.log("Telegram WebApp initDataUnsafe: ", WebApp.initDataUnsafe);
-      } else {
-        console.warn("Telegram WebApp is not available");
-      }
-    }
-  }, []);
-
-  const ctxValue = React.useMemo(
-    () => ({ setHeader, setHeaderVisible }),
-    [setHeader, setHeaderVisible],
-  );
-
   return (
-    <HeaderContext.Provider value={ctxValue}>
-      {renderHeaderBlock && (
-        <div
-          style={{ height: 60 }}
-          className="w-full flex items-center border-b bg-white/80 dark:bg-slate-900/60 backdrop-blur"
-        >
-          {headerVisible && (
-            <div className="w-full max-w-7xl mx-auto px-4">{header}</div>
-          )}
-        </div>
-      )}
+    <TelegramHeaderProvider>
       <Outlet />
-    </HeaderContext.Provider>
+    </TelegramHeaderProvider>
   );
 };
 
 export default CommonLayout;
-export { HeaderContext };
+export { useCustomHeader };

--- a/src/layout/TelegramHeader.tsx
+++ b/src/layout/TelegramHeader.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect } from "react";
+import WebApp from "@twa-dev/sdk";
+import { cn } from "@/lib/utils";
+
+type HeaderContextType = {
+  setHeader: (node: React.ReactNode | null) => void;
+  setHeaderVisible: (visible: boolean) => void;
+};
+
+type TelegramHeaderProviderProps = {
+  children: React.ReactNode;
+  containerClassName?: string;
+  contentWrapperClassName?: string;
+  headerHeight?: number;
+};
+
+const HeaderContext = React.createContext<HeaderContextType | undefined>(
+  undefined,
+);
+
+/**
+ * Hook for child pages to set custom header content and control visibility of the common header.
+ *
+ * Example usage inside a page component:
+ *   useCustomHeader(<MyHeaderContent />, { visible: true });
+ */
+export function useCustomHeader(
+  content?: React.ReactNode,
+  options?: { visible?: boolean; deps?: React.DependencyList },
+) {
+  const ctx = React.useContext(HeaderContext);
+  // If used outside of TelegramHeaderProvider, do nothing to avoid runtime errors
+  if (!ctx) return;
+
+  const { setHeader, setHeaderVisible } = ctx;
+  const visible = options?.visible ?? true;
+  const deps = options?.deps ?? [content, visible];
+
+  React.useEffect(() => {
+    if (visible) {
+      setHeader(content ?? null);
+      setHeaderVisible(true);
+    } else {
+      setHeaderVisible(false);
+    }
+    return () => {
+      // Cleanup on unmount or dependency change
+      setHeader(null);
+      setHeaderVisible(false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}
+
+export function TelegramHeaderProvider({
+  children,
+  containerClassName,
+  contentWrapperClassName,
+  headerHeight = 60,
+}: TelegramHeaderProviderProps) {
+  const [header, setHeader] = React.useState<React.ReactNode | null>(null);
+  const [renderHeaderBlock, setRenderHeaderBlock] =
+    React.useState<boolean>(false);
+  const [headerVisible, setHeaderVisible] = React.useState<boolean>(false);
+
+  useEffect(() => {
+    if (WebApp) {
+      WebApp.ready();
+      if (
+        WebApp.initDataUnsafe &&
+        Object.keys(WebApp.initDataUnsafe).length > 0
+      ) {
+        setRenderHeaderBlock(WebApp.isFullscreen);
+        console.log("Telegram WebApp is available: ", WebApp);
+        console.log("Telegram WebApp initDataUnsafe: ", WebApp.initDataUnsafe);
+      } else {
+        console.warn("Telegram WebApp is not available");
+      }
+    }
+  }, []);
+
+  const ctxValue = React.useMemo(
+    () => ({ setHeader, setHeaderVisible }),
+    [setHeader, setHeaderVisible],
+  );
+
+  return (
+    <HeaderContext.Provider value={ctxValue}>
+      {renderHeaderBlock && (
+        <div
+          style={{ height: headerHeight }}
+          className={cn(
+            "w-full flex items-center border-b bg-white/80 dark:bg-slate-900/60 backdrop-blur",
+            containerClassName,
+          )}
+        >
+          {headerVisible && (
+            <div
+              className={cn(
+                "w-full max-w-7xl mx-auto px-4",
+                contentWrapperClassName,
+              )}
+            >
+              {header}
+            </div>
+          )}
+        </div>
+      )}
+      {children}
+    </HeaderContext.Provider>
+  );
+}
+
+export { HeaderContext };

--- a/src/layout/WebLayout.tsx
+++ b/src/layout/WebLayout.tsx
@@ -1,43 +1,52 @@
-import React, {type ReactNode} from 'react';
-import {SidebarInset, SidebarProvider, SidebarTrigger} from "@/components/ui/sidebar.tsx";
-import {AppSidebar} from "@/components/sidebar/app-sidebar.tsx";
-import {Separator} from "@/components/ui/separator.tsx";
-import {BreadcrumbComponent} from "@/components/BreadcrumbComponent.tsx";
-import {Toaster} from "@/components/ui/sonner.tsx";
-import LanguageSelector, {LanguageSelectorMode} from "@/components/lang/LanguageSelector.tsx";
-import {ModeToggle} from "@/components/theme/mode-toggle.tsx";
+import React, { type ReactNode } from "react";
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar.tsx";
+import { AppSidebar } from "@/components/sidebar/app-sidebar.tsx";
+import { Separator } from "@/components/ui/separator.tsx";
+import { BreadcrumbComponent } from "@/components/BreadcrumbComponent.tsx";
+import { Toaster } from "@/components/ui/sonner.tsx";
+import LanguageSelector, {
+  LanguageSelectorMode,
+} from "@/components/lang/LanguageSelector.tsx";
+import { ModeToggle } from "@/components/theme/mode-toggle.tsx";
+import { TelegramHeaderProvider } from "@/layout/TelegramHeader";
 
 interface LayoutProps {
-    children: ReactNode;
+  children: ReactNode;
 }
 
-const WebLayout: React.FC<LayoutProps> = ({children}) => {
-    return (
-        <SidebarProvider>
-            <AppSidebar/>
-            <SidebarInset>
-                <header className="flex h-16 shrink-0 items-center justify-between px-4">
-                    {/* Left: Sidebar trigger + breadcrumb */}
-                    <div className="flex items-center gap-2">
-                        <SidebarTrigger className="-ml-1"/>
-                        <Separator
-                            orientation="vertical"
-                            className="mr-2 data-[orientation=vertical]:h-4"
-                        />
-                        <BreadcrumbComponent/>
-                    </div>
+const WebLayout: React.FC<LayoutProps> = ({ children }) => {
+  return (
+    <TelegramHeaderProvider contentWrapperClassName="max-w-none px-4">
+      <SidebarProvider>
+        <AppSidebar />
+        <SidebarInset>
+          <header className="flex h-16 shrink-0 items-center justify-between px-4">
+            {/* Left: Sidebar trigger + breadcrumb */}
+            <div className="flex items-center gap-2">
+              <SidebarTrigger className="-ml-1" />
+              <Separator
+                orientation="vertical"
+                className="mr-2 data-[orientation=vertical]:h-4"
+              />
+              <BreadcrumbComponent />
+            </div>
 
-                    {/* Right: Language marker + dropdown */}
-                    <div className="flex items-center gap-2">
-                        <LanguageSelector mode={LanguageSelectorMode.FULL}/>
-                        <ModeToggle/>
-                    </div>
-                </header>
-                <main>{children}</main>
-                <Toaster position="top-center"/>
-            </SidebarInset>
-        </SidebarProvider>
-    );
+            {/* Right: Language marker + dropdown */}
+            <div className="flex items-center gap-2">
+              <LanguageSelector mode={LanguageSelectorMode.FULL} />
+              <ModeToggle />
+            </div>
+          </header>
+          <main>{children}</main>
+          <Toaster position="top-center" />
+        </SidebarInset>
+      </SidebarProvider>
+    </TelegramHeaderProvider>
+  );
 };
 
 export default WebLayout;

--- a/src/pages/PrivateMenuPage.tsx
+++ b/src/pages/PrivateMenuPage.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { useCustomHeader } from "@/layout/TelegramHeader";
+
+const PrivateMenuPage: React.FC = () => {
+  const headerNode = React.useMemo(
+    () => (
+      <div className="flex items-center justify-center-safe w-full h-full px-2">
+        <span className="text-lg font-semibold leading-none">
+          Private Menu
+        </span>
+      </div>
+    ),
+    [],
+  );
+
+  useCustomHeader(headerNode, { visible: true, deps: [headerNode] });
+
+  return (
+    <section className="px-4 py-6">
+      <h1 className="text-2xl font-semibold">Private Menu</h1>
+    </section>
+  );
+};
+
+export default PrivateMenuPage;


### PR DESCRIPTION
### Motivation
- Provide a reusable Telegram fullscreen header block that reserves safe-area space so page content is not hidden by inaccessible touch areas when the app runs inside Telegram WebApp fullscreen. 
- Allow pages (including those using `WebLayout`) to set an optional header/title visible in Telegram fullscreen and add a simple private menu page demonstrating the integration.

### Description
- Add a new `TelegramHeaderProvider` and `useCustomHeader` hook in `src/layout/TelegramHeader.tsx` to centralize Telegram WebApp detection and optional header rendering with configurable `headerHeight` and CSS wrapper classes. 
- Replace the inline header handling in `CommonLayout` with the new `TelegramHeaderProvider` and re-export `useCustomHeader` from `CommonLayout` for compatibility via `src/layout/CommonLayout.tsx`. 
- Wrap `WebLayout` with `TelegramHeaderProvider` (passing `contentWrapperClassName=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c949a54a483269f821f69751b826e)